### PR TITLE
add tinybird api clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Verdin
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 
-Verdin is a [tiny bird](https://en.wikipedia.org/wiki/Verdin), and also a [Tinybird](https://tinybird.co) SDK for Python
-.
+Verdin is a [tiny bird](https://en.wikipedia.org/wiki/Verdin), and also a [Tinybird](https://tinybird.co) SDK for Python.
 
 Install
 -------
@@ -127,6 +126,9 @@ The following APIs are available:
 
 Note that for some (datasources, pipes, tokens), manipulation operations are not implemented as they are typically done
 through tb deployments and not through the API.
+
+Also note that API clients do not take care of retries or rate limiting. The caller is expected to handle fault
+tolerance.
 
 #### Example (Querying a pipe)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ response: tinybird.PipeJsonResponse = pipe.query({"key": "val"})
 print(response.data)
 ```
 
-### Append to a DataSource
+### Append to a data source
 
 ```python
 from verdin import tinybird
@@ -72,6 +72,19 @@ datasource = client.datasource("my_datasource", version=0)
 datasource.append([
     ("col1-row1", "col2-row1"),
     ("col1-row2", "col2-row2"),
+])
+```
+
+### Append to a data source using high-frequency ingest
+
+The `DataSource` object also gives you access to `/v0/events`, which is the high-frequency ingest, to append data.
+Use the `send_events` method and pass JSON serializable documents to it.
+
+```python
+datasource.send_events(records=[
+    {"key": "val1"},
+    {"key": "val2"},
+    ...
 ])
 ```
 
@@ -98,6 +111,58 @@ Thread(target=appender.run).start()
 
 records.put(("col1-row1", "col2-row1"))
 records.put(("col1-row2", "col2-row2"))
+```
+
+### API access
+
+The DataSource and Pipes objects presented so far are high-level abstractions that provide a convenience Python API
+to deal with the most common use cases. Verdin also provides more low-level access to APIs via `client.api`.
+The following APIs are available:
+
+* `/v0/datasources`: `client.api.datasources`
+* `/v0/events`: `client.api.events`
+* `/v0/pipes`: `client.api.pipes`
+* `/v0/tokens`: `client.api.tokens`
+* `/v0/variables`: `client.api.variables`
+
+Note that for some (datasources, pipes, tokens), manipulation operations are not implemented as they are typically done
+through tb deployments and not through the API.
+
+#### Example (Querying a pipe)
+
+You can query a pipe through the pipes API as follows:
+
+```python
+from verdin import tinybird
+
+client = tinybird.Client(...)
+
+response = client.api.pipes.query(
+    "my_pipe",
+    parameters={"my_param": "..."},
+    query="SELECT * FROM _ LIMIT 10",
+)
+
+for record in response.data:
+    # each record is a dictionary
+    ...
+```
+
+#### Example (High-frequency ingest)
+
+You can use the HFI endpoint `/v0/events` through the `events` api. As records, you can pass a list of JSON serializable
+documents.
+
+```python
+from verdin import tinybird
+
+client = tinybird.Client(...)
+
+response = client.api.events.send("my_datasource", records=[
+    {"id": "...", "value": "..."},
+    ...
+])
+assert response.quarantined_rows == 0
 ```
 
 Develop

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ from verdin.client import Client
 from verdin.test.cli import TinybirdCli
 from verdin.test.container import TinybirdLocalContainer
 
-# os.environ["SKIP_TINYBIRD_LOCAL_START"] = "1"
+os.environ["SKIP_TINYBIRD_LOCAL_START"] = "1"
 
 
 def _is_skip_tinybird_local_start() -> bool:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,7 +8,7 @@ from verdin.client import Client
 from verdin.test.cli import TinybirdCli
 from verdin.test.container import TinybirdLocalContainer
 
-os.environ["SKIP_TINYBIRD_LOCAL_START"] = "1"
+# os.environ["SKIP_TINYBIRD_LOCAL_START"] = "1"
 
 
 def _is_skip_tinybird_local_start() -> bool:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 
+from verdin.api import ApiError
 from verdin.client import Client
 from verdin.test.cli import TinybirdCli
 from verdin.test.container import TinybirdLocalContainer
@@ -64,3 +65,23 @@ def deployed_project(cli):
     time.sleep(5)
     cli.deploy(wait=True, auto=True)
     yield
+
+
+@pytest.fixture(autouse=True)
+def _truncate_datasource(self, client):
+    # make sure to truncate "simple" datasource and its quarantine table before and after each test
+
+    client.api.datasources.truncate("simple")
+    try:
+        # also truncate the quarantine table if it exists
+        client.api.datasources.truncate("simple_quarantine")
+    except ApiError:
+        pass
+
+    yield
+    client.api.datasources.truncate("simple")
+
+    try:
+        client.api.datasources.truncate("simple_quarantine")
+    except ApiError:
+        pass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,7 +68,7 @@ def deployed_project(cli):
 
 
 @pytest.fixture(autouse=True)
-def _truncate_datasource(self, client):
+def _truncate_datasource(client):
     # make sure to truncate "simple" datasource and its quarantine table before and after each test
 
     client.api.datasources.truncate("simple")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,7 +8,7 @@ from verdin.client import Client
 from verdin.test.cli import TinybirdCli
 from verdin.test.container import TinybirdLocalContainer
 
-# os.environ["SKIP_TINYBIRD_LOCAL_START"] = "1"
+os.environ["SKIP_TINYBIRD_LOCAL_START"] = "1"
 
 
 def _is_skip_tinybird_local_start() -> bool:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ from verdin.client import Client
 from verdin.test.cli import TinybirdCli
 from verdin.test.container import TinybirdLocalContainer
 
-os.environ["SKIP_TINYBIRD_LOCAL_START"] = "1"
+# os.environ["SKIP_TINYBIRD_LOCAL_START"] = "1"
 
 
 def _is_skip_tinybird_local_start() -> bool:

--- a/tests/integration/project/endpoints/simple_pipe.pipe
+++ b/tests/integration/project/endpoints/simple_pipe.pipe
@@ -1,0 +1,14 @@
+VERSION 0
+
+DESCRIPTION >
+    Endpoint to select specific keys from the table
+
+NODE endpoint
+SQL >
+    %
+    SELECT *
+    FROM simple
+    WHERE 1=1
+        {% if defined(key) %} AND key == {{ String(key) }} {% end %}
+
+TYPE ENDPOINT

--- a/tests/integration/test_datasources.py
+++ b/tests/integration/test_datasources.py
@@ -8,16 +8,6 @@ from tests.utils import retry
 
 
 class TestDataSourcesApi:
-    @pytest.fixture(autouse=True)
-    def _truncate_datasource(self, client):
-        # make sure to truncate "simple" datasource and its quarantine table before and after each test
-
-        client.api.datasources.truncate("simple")
-        client.api.datasources.truncate("simple_quarantine")
-        yield
-        client.api.datasources.truncate("simple")
-        client.api.datasources.truncate("simple_quarantine")
-
     def test_list(self, client):
         response = client.api.datasources.list()
 

--- a/tests/integration/test_datasources.py
+++ b/tests/integration/test_datasources.py
@@ -1,0 +1,176 @@
+import json
+
+import pytest
+
+from verdin.api import ApiError
+from verdin.api.datasources import DataSourceNotFoundError
+from tests.utils import retry
+
+
+class TestDataSourcesApi:
+    @pytest.fixture(autouse=True)
+    def _truncate_datasource(self, client):
+        # make sure to truncate "simple" datasource and its quarantine table before and after each test
+
+        client.api.datasources.truncate("simple")
+        client.api.datasources.truncate("simple_quarantine")
+        yield
+        client.api.datasources.truncate("simple")
+        client.api.datasources.truncate("simple_quarantine")
+
+    def test_list(self, client):
+        response = client.api.datasources.list()
+
+        assert len(response.datasources) >= 1
+
+        # find "simple" datasource in the list of data sources
+        ds = None
+        for datasource in response.datasources:
+            if datasource["name"] == "simple":
+                ds = datasource
+                break
+
+        assert ds
+
+        # smoke tests some attributes
+        assert ds["engine"]["engine"] == "MergeTree"
+        assert "simple_kv" in [x["name"] for x in ds["used_by"]]
+
+    def test_get_information(self, client):
+        response = client.api.datasources.get_information("simple")
+
+        # smoke tests some attributes
+        assert response.info["name"] == "simple"
+        assert response.info["engine"]["engine"] == "MergeTree"
+        assert "simple_kv" in [x["name"] for x in response.info["used_by"]]
+
+    def test_get_information_on_non_existing_datasource(self, client):
+        with pytest.raises(DataSourceNotFoundError) as e:
+            client.api.datasources.get_information("non_existing_datasource")
+
+        e.match('Data Source "non_existing_datasource" does not exist')
+        assert e.value.status_code == 404
+
+    def test_truncate(self, client):
+        ds = client.datasource("simple")
+        ds.append_ndjson(
+            [
+                {
+                    "Id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                    "Timestamp": "2024-01-23T10:30:00.123456",
+                    "Key": "foo",
+                    "Value": "bar",
+                },
+                {
+                    "Id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                    "Timestamp": "2024-02-23T11:45:00.234567",
+                    "Key": "baz",
+                    "Value": "ed",
+                },
+            ]
+        )
+
+        def _wait_for_count(cnt: int):
+            query = client.sql("SELECT count(*) as cnt FROM simple")
+            assert query.json().data == [{"cnt": cnt}]
+
+        retry(_wait_for_count, args=(2,))
+
+        client.api.datasources.truncate("simple")
+
+        retry(_wait_for_count, args=(0,))
+
+    def test_append_to_non_existing_data_source(self, client):
+        with pytest.raises(ApiError) as e:
+            client.api.datasources.append("non_existing_datasource", "foo,bar\n")
+
+        # this is odd behavior, but currently, this raises a 403, with the error
+        # "Adding or modifying data sources to this workspace can only be done via deployments"
+        # due to the way tinybird behaves (apparently it doesn't check mode=append)
+
+        assert e.value.status_code == 403
+
+    def test_append_csv(self, client):
+        ds = client.api.datasources
+
+        data = "5b6859d2-e060-40a4-949a-7e7fab8e3207,2024-01-23T10:30:00.123456,foo,bar\n"
+        data += "af49ffce-559c-426e-9787-ddb08628b547,2024-02-23T11:45:00.234567,baz,ed"
+
+        response = ds.append("simple", data)
+        assert not response.error
+        assert response.quarantine_rows == 0
+        assert response.invalid_lines == 0
+        assert response.datasource["name"] == "simple"
+
+        assert client.sql("SELECT * FROM simple").json().data == [
+            {
+                "id": "5b6859d2-e060-40a4-949a-7e7fab8e3207",
+                "timestamp": "2024-01-23 10:30:00.123456",
+                "key": "foo",
+                "value": "bar",
+            },
+            {
+                "id": "af49ffce-559c-426e-9787-ddb08628b547",
+                "timestamp": "2024-02-23 11:45:00.234567",
+                "key": "baz",
+                "value": "ed",
+            },
+        ]
+
+    def test_append_csv_with_invalid_data(self, client):
+        ds = client.api.datasources
+
+        data = "5b6859d2-e060-40a4-949a-7e7fab8e3207,2024-01-23T10:30:00.123456,foo,bar\n"
+        data += "af49ffce-559c-426e-9787-ddb08628b5472024-02-23T11:45:00.234567,baz,ed"  # error in this line
+
+        response = ds.append("simple", data)
+        assert (
+            response.error
+            == "There was an error with file contents: 1 row in quarantine and 1 invalid line."
+        )
+        assert response.invalid_lines == 1
+        assert response.quarantine_rows == 1
+
+    def test_append_ndjson(self, client):
+        ds = client.api.datasources
+        ds.truncate("simple")
+
+        records = [
+            {
+                "Id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                "Timestamp": "2024-01-23T10:30:00.123456",
+                "Key": "foo",
+                "Value": "bar",
+            },
+            {
+                "Id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                "Timestamp": "2024-02-23T11:45:00.234567",
+                "Key": "baz",
+                "Value": "ed",
+            },
+        ]
+
+        def _data():
+            for r in records:
+                yield json.dumps(r) + "\n"
+
+        response = ds.append("simple", _data(), format="ndjson")
+        assert not response.error
+        assert response.quarantine_rows == 0
+        assert response.invalid_lines == 0
+        assert response.datasource["name"] == "simple"
+
+        assert client.sql("SELECT * FROM simple").json().data == [
+            {
+                "id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                "timestamp": "2024-01-23 10:30:00.123456",
+                "key": "foo",
+                "value": "bar",
+            },
+            {
+                "id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                "timestamp": "2024-02-23 11:45:00.234567",
+                "key": "baz",
+                "value": "ed",
+            },
+        ]

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -4,16 +4,6 @@ from tests.utils import retry
 
 
 class TestEventsApi:
-    @pytest.fixture(autouse=True)
-    def _truncate_datasource(self, client):
-        # make sure to truncate "simple" datasource and its quarantine table before and after each test
-
-        client.api.datasources.truncate("simple")
-        client.api.datasources.truncate("simple_quarantine")
-        yield
-        client.api.datasources.truncate("simple")
-        client.api.datasources.truncate("simple_quarantine")
-
     @pytest.mark.parametrize("compress", [True, False])
     def test_events(self, client, compress):
         events = client.api.events

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,0 +1,71 @@
+import pytest
+
+from tests.utils import retry
+
+
+class TestEventsApi:
+    @pytest.fixture(autouse=True)
+    def _truncate_datasource(self, client):
+        # make sure to truncate "simple" datasource and its quarantine table before and after each test
+
+        client.api.datasources.truncate("simple")
+        client.api.datasources.truncate("simple_quarantine")
+        yield
+        client.api.datasources.truncate("simple")
+        client.api.datasources.truncate("simple_quarantine")
+
+    @pytest.mark.parametrize("compress", [True, False])
+    def test_events(self, client, compress):
+        events = client.api.events
+
+        records = [
+            {
+                "Id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                "Timestamp": "2024-01-23T10:30:00.123456",
+                "Key": "foo",
+                "Value": "bar",
+            },
+            {
+                "Id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                "Timestamp": "2024-02-23T11:45:00.234567",
+                "Key": "baz",
+                "Value": "ed",
+            },
+        ]
+
+        response = events.send("simple", records, compress=compress)
+
+        assert response.successful_rows == 2
+        assert response.quarantined_rows == 0
+
+        def _wait_for_count(cnt: int):
+            query = client.sql("SELECT count(*) as cnt FROM simple")
+            assert query.json().data == [{"cnt": cnt}]
+
+        retry(_wait_for_count, args=(2,))
+
+    def test_events_wait(self, client):
+        events = client.api.events
+
+        records = [
+            {
+                "Id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                "Timestamp": "2024-01-23T10:30:00.123456",
+                "Key": "foo",
+                "Value": "bar",
+            },
+            {
+                "Id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                "Timestamp": "2024-02-23T11:45:00.234567",
+                "Key": "baz",
+                "Value": "ed",
+            },
+        ]
+
+        response = events.send("simple", records, wait=True)
+
+        assert response.successful_rows == 2
+        assert response.quarantined_rows == 0
+
+        query = client.sql("SELECT count(*) as cnt FROM simple")
+        assert query.json().data == [{"cnt": 2}]

--- a/tests/integration/test_pipes.py
+++ b/tests/integration/test_pipes.py
@@ -1,0 +1,220 @@
+import pytest
+
+from verdin.api.pipes import PipeNotFoundError
+
+
+class TestPipesApi:
+    @pytest.fixture(autouse=True)
+    def _truncate_datasource(self, client):
+        # make sure to truncate "simple" datasource and its quarantine table before and after each test
+
+        client.api.datasources.truncate("simple")
+        client.api.datasources.truncate("simple_quarantine")
+        yield
+        client.api.datasources.truncate("simple")
+        client.api.datasources.truncate("simple_quarantine")
+
+    def test_list(self, client):
+        response = client.api.pipes.list(
+            attrs=["id", "name"],
+            node_attrs=[],
+        )
+
+        for pipe in response.pipes:
+            assert {"id", "name", "url"} == set(pipe.keys())
+            assert pipe["id"] is not None
+            assert pipe["name"] is not None
+
+        assert "simple_kv" in [pipe["name"] for pipe in response.pipes]
+        assert "simple_pipe" in [pipe["name"] for pipe in response.pipes]
+
+    def test_query_json(self, client):
+        client.api.events.send(
+            "simple",
+            wait=True,
+            records=[
+                {
+                    "Id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                    "Timestamp": "2024-01-23T10:30:00.123456",
+                    "Key": "foo",
+                    "Value": "bar",
+                },
+                {
+                    "Id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                    "Timestamp": "2024-02-23T11:45:00.234567",
+                    "Key": "baz",
+                    "Value": "ed",
+                },
+            ],
+        )
+
+        response = client.api.pipes.query("simple_kv", format="json")
+        assert response.data == [{"key": "baz", "value": "ed"}, {"key": "foo", "value": "bar"}]
+        assert response.meta == [
+            {"name": "key", "type": "String"},
+            {"name": "value", "type": "String"},
+        ]
+        assert response.rows == 2
+        assert response.statistics["rows_read"] == 2
+
+    @pytest.mark.parametrize("format", ["csv", "ndjson", "json"])
+    def test_query_formats(self, client, format):
+        client.api.events.send(
+            "simple",
+            wait=True,
+            records=[
+                {
+                    "Id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                    "Timestamp": "2024-01-23T10:30:00.123456",
+                    "Key": "foo",
+                    "Value": "bar",
+                },
+                {
+                    "Id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                    "Timestamp": "2024-02-23T11:45:00.234567",
+                    "Key": "baz",
+                    "Value": "ed",
+                },
+                {
+                    "Id": "2b84e03e-dbcf-4141-9656-94ff8ac8c036",
+                    "Timestamp": "2024-03-23T11:45:00.345678",
+                    "Key": "format",
+                    "Value": format,
+                },
+            ],
+        )
+
+        response = client.api.pipes.query("simple_kv", format=format)
+        assert response.data == [
+            {"key": "baz", "value": "ed"},
+            {"key": "foo", "value": "bar"},
+            {"key": "format", "value": format},
+        ]
+
+    def test_query_with_params(self, client):
+        client.api.events.send(
+            "simple",
+            wait=True,
+            records=[
+                {
+                    "Id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                    "Timestamp": "2024-01-23T10:30:00.123456",
+                    "Key": "foo",
+                    "Value": "bar",
+                },
+                {
+                    "Id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                    "Timestamp": "2024-02-23T11:45:00.234567",
+                    "Key": "baz",
+                    "Value": "ed",
+                },
+                {
+                    "Id": "2b84e03e-dbcf-4141-9656-94ff8ac8c036",
+                    "Timestamp": "2024-03-23T11:45:00.345678",
+                    "Key": "foo",
+                    "Value": "bar2",
+                },
+            ],
+        )
+
+        response = client.api.pipes.query("simple_pipe", parameters={"key": "foo"})
+        assert response.data == [
+            {
+                "id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                "key": "foo",
+                "timestamp": "2024-01-23 10:30:00.123456",
+                "value": "bar",
+            },
+            {
+                "id": "2b84e03e-dbcf-4141-9656-94ff8ac8c036",
+                "key": "foo",
+                "timestamp": "2024-03-23 11:45:00.345678",
+                "value": "bar2",
+            },
+        ]
+
+        response = client.api.pipes.query("simple_pipe", parameters={"key": "does not exist"})
+        assert response.data == []
+
+    def test_query_with_sql(self, client):
+        client.api.events.send(
+            "simple",
+            wait=True,
+            records=[
+                {
+                    "Id": "e7f2af3e-99d1-4d4f-8a8c-d6aee4ab89b0",
+                    "Timestamp": "2024-01-23T10:30:00.123456",
+                    "Key": "foo",
+                    "Value": "bar",
+                },
+                {
+                    "Id": "d7792957-21d8-46e6-a4e0-188eb36e2758",
+                    "Timestamp": "2024-02-23T11:45:00.234567",
+                    "Key": "baz",
+                    "Value": "ed",
+                },
+                {
+                    "Id": "2b84e03e-dbcf-4141-9656-94ff8ac8c036",
+                    "Timestamp": "2024-03-23T11:45:00.345678",
+                    "Key": "foo",
+                    "Value": "bar2",
+                },
+            ],
+        )
+
+        response = client.api.pipes.query(
+            "simple_pipe",
+            query="SELECT timestamp,key,value FROM _ ORDER BY `value` DESC",
+            parameters={"key": "foo"},
+        )
+
+        assert response.data == [
+            {
+                "timestamp": "2024-03-23 11:45:00.345678",
+                "key": "foo",
+                "value": "bar2",
+            },
+            {
+                "timestamp": "2024-01-23 10:30:00.123456",
+                "key": "foo",
+                "value": "bar",
+            },
+        ]
+
+    def test_query_with_sql_too_long(self, client):
+        chars = "a" * 6000
+        # ``chars`` ends up in both the query and parameters, making the total body ~12k, but the query <8k, which is a
+        # requirement.
+
+        response = client.api.pipes.query(
+            "simple_pipe",
+            query=f"SELECT * FROM _ WHERE `value` = '{chars}'",
+            parameters={"key": chars},
+        )
+
+        # ofcourse the query is nonsense and returns nothing
+        assert response.data == []
+
+    def test_query_with_non_existing_pipe(self, client):
+        with pytest.raises(PipeNotFoundError) as e:
+            client.api.pipes.query("non_existent_pipe")
+
+        assert e.match("The pipe 'non_existent_pipe' does not exist")
+        assert e.value.status_code == 404
+
+    def test_get_information(self, client):
+        response = client.api.pipes.get_information("simple_kv")
+        assert response.info["name"] == "simple_kv"
+        assert response.info["type"] == "endpoint"
+
+        # check that it also works with the pipe's ID
+        response = client.api.pipes.get_information(response.info["id"])
+        assert response.info["name"] == "simple_kv"
+        assert response.info["type"] == "endpoint"
+
+    def test_get_information_non_existing_pipe(self, client):
+        with pytest.raises(PipeNotFoundError) as e:
+            client.api.pipes.get_information("non_existent_pipe")
+
+        assert e.match("Pipe 'non_existent_pipe' not found")
+        assert e.value.status_code == 404

--- a/tests/integration/test_pipes.py
+++ b/tests/integration/test_pipes.py
@@ -4,16 +4,6 @@ from verdin.api.pipes import PipeNotFoundError
 
 
 class TestPipesApi:
-    @pytest.fixture(autouse=True)
-    def _truncate_datasource(self, client):
-        # make sure to truncate "simple" datasource and its quarantine table before and after each test
-
-        client.api.datasources.truncate("simple")
-        client.api.datasources.truncate("simple_quarantine")
-        yield
-        client.api.datasources.truncate("simple")
-        client.api.datasources.truncate("simple_quarantine")
-
     def test_list(self, client):
         response = client.api.pipes.list(
             attrs=["id", "name"],

--- a/tests/integration/test_tokens.py
+++ b/tests/integration/test_tokens.py
@@ -1,0 +1,31 @@
+import pytest
+
+from verdin.api import ApiError
+
+
+class TestTokensApi:
+    def test_list(self, client):
+        api = client.api.tokens
+        tokens = api.list().tokens
+        assert tokens
+        assert "admin local_testing@tinybird.co" in [token["name"] for token in tokens]
+
+    def test_get_information(self, client):
+        api = client.api.tokens
+
+        token = api.get_information("admin local_testing@tinybird.co").info
+        assert token["name"] == "admin local_testing@tinybird.co"
+        assert token["token"].startswith("p.e")
+
+        # make sure it also works with the id
+        token = api.get_information(token["id"]).info
+        assert token["name"] == "admin local_testing@tinybird.co"
+
+    def test_get_information_on_non_existing_token(self, client):
+        api = client.api.tokens
+
+        with pytest.raises(ApiError) as e:
+            api.get_information("NON EXISTING TOKEN")
+
+        assert e.match("Token has not enough permissions to get information about this token")
+        assert e.value.status_code == 403

--- a/tests/integration/test_variables.py
+++ b/tests/integration/test_variables.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+import time
+
+import pytest
+
+from tests.utils import short_id
+from verdin.api.variables import VariableNotFoundError
+
+
+class TestVariables:
+    def test_integration(self, client):
+        # E2E test for variables API
+        variable_name = f"test_variable_{short_id()}"
+        variable_value = "test_value"
+
+        # List variables and make sure the variable_name is not in the list
+        response = client.api.variables.list()
+        variable_names = [var["name"] for var in response.variables]
+        assert variable_name not in variable_names
+
+        # Make sure an API Error with 404 is raised when getting a non-existent variable
+        with pytest.raises(VariableNotFoundError) as e:
+            client.api.variables.get(variable_name)
+        assert e.value.status_code == 404
+
+        # Create the variable
+        create_response = client.api.variables.create(name=variable_name, value=variable_value)
+        assert create_response.variable["name"] == variable_name
+        assert create_response.variable["type"] == "secret"
+
+        # List again and check that it's there
+        list_response = client.api.variables.list()
+        variable_names = [var["name"] for var in list_response.variables]
+        assert variable_name in variable_names
+
+        # Get the variable and assert the response
+        get_response = client.api.variables.get(variable_name)
+        assert get_response.variable["name"] == variable_name
+        assert get_response.variable["type"] == "secret"
+
+        # delete the variable and check again
+        response = client.api.variables.delete(variable_name)
+        assert response.ok
+
+        with pytest.raises(VariableNotFoundError) as e:
+            client.api.variables.get(variable_name)
+
+    def test_get_non_existing_variable(self, client):
+        with pytest.raises(VariableNotFoundError) as e:
+            client.api.variables.get("non_existing_variable")
+
+        assert e.match("Not found")
+        assert e.value.status_code == 404
+
+    def test_delete_non_existing_variable(self, client):
+        with pytest.raises(VariableNotFoundError) as e:
+            client.api.variables.delete("non_existing_variable")
+
+        assert e.match("Variable not found")
+        assert e.value.status_code == 404
+
+    def test_update_non_existing_variable(self, client):
+        with pytest.raises(VariableNotFoundError) as e:
+            client.api.variables.update("non_existing_variable", value="foo")
+
+        assert e.match("Variable not found")
+        assert e.value.status_code == 404
+
+    def test_update_variable(self, client):
+        variable_name = f"test_variable_{short_id()}"
+        variable_value = "test_value"
+
+        response = client.api.variables.create(name=variable_name, value=variable_value)
+
+        assert datetime.fromisoformat(response.variable["created_at"]).replace(
+            microsecond=0
+        ) == datetime.fromisoformat(response.variable["updated_at"]).replace(microsecond=0)
+
+        time.sleep(1)
+
+        response = client.api.variables.update(name=variable_name, value=variable_value + "1")
+        assert response.variable["created_at"] != response.variable["updated_at"]
+
+        client.api.variables.delete(variable_name)

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -31,7 +31,12 @@ class TestDatasource:
 
         httpserver.expect_request(
             "/v0/datasources",
-            query_string={"name": "mydatasource", "mode": "append", "dialect_delimiter": ","},
+            query_string={
+                "name": "mydatasource",
+                "mode": "append",
+                "dialect_delimiter": ",",
+                "format": "csv",
+            },
         ).respond_with_handler(handler)
 
         response = ds.append([["a", "1", "{}"], ["b", "2", '{"foo":"bar","baz":"ed"}']])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tests.utils import retry
+
+
+def test_retry():
+    assert retry(lambda: "foo") == "foo"
+    assert retry(lambda x: f"foo: {x}", kwargs={"x": "bar"}) == "foo: bar"
+    assert retry(lambda x: f"foo: {x}", args=("bar",)) == "foo: bar"
+
+
+def test_retry_error():
+    def _raise_error():
+        raise ValueError("oh noes")
+
+    with pytest.raises(TimeoutError) as e:
+        retry(_raise_error, retries=2, interval=0.1)
+
+    assert e.match("oh noes")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,39 @@
+import time
+from typing import Callable
+
+
+def retry(
+    fn: Callable,
+    args: tuple = None,
+    kwargs: dict = None,
+    retries: int = 3,
+    interval: float = 1,
+):
+    """
+    Retries the execution of a function ``fn`` for a specified number of attempts (``retries``) with a delay
+    between attempts (``interval``). If all attempts fail, a ``TimeoutError`` is raised indicating the final
+    error encountered.
+
+    :param fn: The callable function to be executed.
+    :param args: A tuple of positional arguments to pass to the ``fn``. Defaults to an empty tuple if not provided.
+    :param kwargs: A dictionary of keyword arguments to pass to the ``fn``. Defaults to an empty dictionary if not
+        provided.
+    :param retries: The number of retry attempts before raising a ``TimeoutError``. Defaults to 3.
+    :param interval: The time (in seconds) to wait between each retry attempt. Defaults to 1.0 seconds.
+    :return: The result returned by successfully calling the ``fn`` with the specified ``args`` and ``kwargs``.
+        Returns `None` only if no successful result is obtained after all retry attempts.
+    """
+    args = args or ()
+    kwargs = kwargs or {}
+
+    for i in range(retries):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:
+            if i == retries - 1:
+                raise TimeoutError(f"Gave up after {retries} retries, final error: {e}") from e
+            else:
+                time.sleep(interval)
+                continue
+
+    return None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 from typing import Callable
 
 
@@ -37,3 +38,7 @@ def retry(
                 continue
 
     return None
+
+
+def short_id() -> str:
+    return str(uuid.uuid4())[-8:]

--- a/verdin/api/__init__.py
+++ b/verdin/api/__init__.py
@@ -1,0 +1,6 @@
+from .base import ApiError, ApiResponse
+
+__all__ = [
+    "ApiError",
+    "ApiResponse",
+]

--- a/verdin/api/apis.py
+++ b/verdin/api/apis.py
@@ -2,6 +2,7 @@ from .datasources import DataSourcesApi
 from .events import EventsApi
 from .pipes import PipesApi
 from .tokens import TokensApi
+from .variables import VariablesApi
 
 
 class Apis:
@@ -31,3 +32,7 @@ class Apis:
     @property
     def tokens(self) -> TokensApi:
         return TokensApi(self._token, self._host)
+
+    @property
+    def variables(self) -> VariablesApi:
+        return VariablesApi(self._token, self._host)

--- a/verdin/api/apis.py
+++ b/verdin/api/apis.py
@@ -1,0 +1,23 @@
+from .datasources import DataSourcesApi
+from .events import EventsApi
+
+
+class Apis:
+    """
+    Factory for Api objects.
+    """
+
+    _token: str
+    _host: str | None
+
+    def __init__(self, token: str, host: str = None):
+        self._token = token
+        self._host = host
+
+    @property
+    def events(self) -> EventsApi:
+        return EventsApi(self._token, self._host)
+
+    @property
+    def datasources(self) -> DataSourcesApi:
+        return DataSourcesApi(self._token, self._host)

--- a/verdin/api/apis.py
+++ b/verdin/api/apis.py
@@ -1,5 +1,6 @@
 from .datasources import DataSourcesApi
 from .events import EventsApi
+from .pipes import PipesApi
 
 
 class Apis:
@@ -21,3 +22,7 @@ class Apis:
     @property
     def datasources(self) -> DataSourcesApi:
         return DataSourcesApi(self._token, self._host)
+
+    @property
+    def pipes(self) -> PipesApi:
+        return PipesApi(self._token, self._host)

--- a/verdin/api/apis.py
+++ b/verdin/api/apis.py
@@ -1,6 +1,7 @@
 from .datasources import DataSourcesApi
 from .events import EventsApi
 from .pipes import PipesApi
+from .tokens import TokensApi
 
 
 class Apis:
@@ -16,13 +17,17 @@ class Apis:
         self._host = host
 
     @property
-    def events(self) -> EventsApi:
-        return EventsApi(self._token, self._host)
-
-    @property
     def datasources(self) -> DataSourcesApi:
         return DataSourcesApi(self._token, self._host)
 
     @property
+    def events(self) -> EventsApi:
+        return EventsApi(self._token, self._host)
+
+    @property
     def pipes(self) -> PipesApi:
         return PipesApi(self._token, self._host)
+
+    @property
+    def tokens(self) -> TokensApi:
+        return TokensApi(self._token, self._host)

--- a/verdin/api/base.py
+++ b/verdin/api/base.py
@@ -1,0 +1,78 @@
+import requests
+
+
+class Api:
+    DEFAULT_HOST = "https://api.tinybird.co"
+
+    host: str
+    token: str
+
+    def __init__(self, token: str, host: str = None):
+        self.token = token
+        self.host = host or Api.DEFAULT_HOST
+
+
+class ApiResponse:
+    _response: requests.Response
+
+    def __init__(self, response: requests.Response):
+        self._response = response
+        self._json: dict | None = None  # cache for json response
+
+    def json(self) -> dict:
+        """
+        Parses the JSON response and returns a dictionary. It caches the result so that later calls to this method
+        do not parse the response every time.
+
+        :return: The parsed JSON response.
+        """
+        if self._json:
+            return self._json
+
+        self._json = self._response.json()
+        return self._json
+
+
+class ApiError(Exception):
+    """
+    Exception that represents a non-200 HTTP response from the API.
+    """
+
+    _response: requests.Response
+
+    def __init__(self, response: requests.Response):
+        self._response = response
+        super().__init__(self._render_message(response))
+
+    def _render_message(self, response: requests.Response) -> str:
+        error = None
+        documentation = None
+
+        if response.headers.get("Content-Type").startswith("application/json"):
+            doc = response.json()
+            error = doc.get("error")
+            documentation = doc.get("documentation")
+
+        if not error:
+            error = response.text
+
+        error.rstrip(".")
+
+        message = f"API Error ({response.status_code}): {error}."
+
+        if documentation:
+            message += f" Documentation: {documentation}"
+
+        return message
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status_code
+
+    @property
+    def text(self) -> str:
+        return self._response.text
+
+    @property
+    def json(self) -> str:
+        return self._response.json()

--- a/verdin/api/base.py
+++ b/verdin/api/base.py
@@ -19,6 +19,25 @@ class ApiResponse:
         self._response = response
         self._json: dict | None = None  # cache for json response
 
+    @property
+    def text(self) -> str:
+        """
+        Returns the body of the HTTP response as a string.
+
+        :return: The response body as a string.
+        """
+        return self._response.text
+
+    @property
+    def content(self) -> bytes:
+        """
+        Returns the body of the HTTP response as bytes.
+
+        :return: The response body as a bytes.
+        """
+        return self._response.content
+
+    @property
     def json(self) -> dict:
         """
         Parses the JSON response and returns a dictionary. It caches the result so that later calls to this method

--- a/verdin/api/datasources.py
+++ b/verdin/api/datasources.py
@@ -148,29 +148,29 @@ class DataSourceAppendInfo(TypedDict):
 class ListDataSourcesResponse(ApiResponse):
     @property
     def datasources(self) -> list[DataSourceInfo]:
-        return self.json().get("datasources", [])
+        return self.json.get("datasources", [])
 
 
 class AppendDataResponse(ApiResponse):
     @property
     def datasource(self) -> DataSourceAppendInfo:
-        return self.json().get("datasource", {})
+        return self.json.get("datasource", {})
 
     @property
     def import_id(self) -> str:
-        return self.json().get("import_id")
+        return self.json.get("import_id")
 
     @property
     def invalid_lines(self) -> int:
-        return self.json().get("invalid_lines")
+        return self.json.get("invalid_lines")
 
     @property
     def quarantine_rows(self) -> int:
-        return self.json().get("quarantine_rows")
+        return self.json.get("quarantine_rows")
 
     @property
     def error(self) -> str | None:
-        error = self.json().get("error")
+        error = self.json.get("error")
         if not error:
             return None
         return error
@@ -201,7 +201,7 @@ class GetDataSourceInformationResponse(ApiResponse):
         }
 
         """
-        return self.json()
+        return self.json
 
 
 class DataSourcesApi(Api):

--- a/verdin/api/datasources.py
+++ b/verdin/api/datasources.py
@@ -1,0 +1,360 @@
+from typing import Literal, Iterable, TypedDict
+
+import requests
+
+from .base import Api, ApiError, ApiResponse
+
+
+class DataSourceNotFoundError(ApiError):
+    """
+    Specific ApiError representing a 404 Not Found when database names are given.
+    """
+
+
+class DataSourceInfo(TypedDict):
+    """
+    A data source info object. Example::
+
+        {
+          "cluster": "tinybird",
+          "created_at": "2025-12-17 13:18:09.799040",
+          "description": "Simple Key-Value Data Source",
+          "engine": {
+            "engine": "MergeTree",
+            "engine_full": "MergeTree ORDER BY tuple()",
+            "sorting_key": "tuple()"
+          },
+          "errors_discarded_at": null,
+          "headers": {},
+          "id": "t_e1ea6e1e32004989af509b034b0987c1",
+          "indexes": [],
+          "last_commit": {
+            "content_sha": "",
+            "path": "",
+            "status": "ok"
+          },
+          "name": "simple",
+          "new_columns_detected": false,
+          "project": null,
+          "replicated": false,
+          "schema": {
+            "columns": [
+              {
+                "auto": false,
+                "codec": null,
+                "default_value": null,
+                "jsonpath": "$.Id",
+                "name": "id",
+                "normalized_name": "id",
+                "nullable": false,
+                "type": "UUID"
+              },
+              {
+                "auto": false,
+                "codec": null,
+                "default_value": null,
+                "jsonpath": "$.Timestamp",
+                "name": "timestamp",
+                "normalized_name": "timestamp",
+                "nullable": false,
+                "type": "DateTime64(6)"
+              },
+              {
+                "auto": false,
+                "codec": null,
+                "default_value": null,
+                "jsonpath": "$.Key",
+                "name": "key",
+                "normalized_name": "key",
+                "nullable": false,
+                "type": "String"
+              },
+              {
+                "auto": false,
+                "codec": null,
+                "default_value": null,
+                "jsonpath": "$.Value",
+                "name": "value",
+                "normalized_name": "value",
+                "nullable": false,
+                "type": "String"
+              }
+            ],
+            "sql_schema": "`id` UUID `json:$.Id`, `timestamp` DateTime64(6) `json:$.Timestamp`, `key` String `json:$.Key`, `value` String `json:$.Value`"
+          },
+          "shared_with": [],
+          "statistics": {
+            "bytes": 0,
+            "row_count": 0
+          },
+          "tags": {},
+          "type": "ndjson",
+          "updated_at": "2025-12-17 13:18:09.799040",
+          "used_by": [
+            {
+              "id": "t_c50152ced57b46b99acf14930b9c6906",
+              "name": "simple_kv"
+            }
+          ],
+          "version": 0
+        }
+    """
+
+    cluster: str
+    created_at: str
+    description: str
+    engine: dict
+    errors_discarded_at: str | None
+    headers: dict
+    id: str
+    indexes: list
+    last_commit: dict
+    name: str
+    new_columns_detected: bool
+    project: str | None
+    replicated: bool
+    schema: dict
+    shared_with: list
+    statistics: dict
+    tags: dict
+    type: str
+    updated_at: str
+    used_by: list[dict]
+    version: int
+
+
+class DataSourceAppendInfo(TypedDict):
+    """Information about a data source returned when appending to the data source."""
+
+    cluster: str
+    created_at: str
+    description: str
+    engine: dict  # TODO: {'engine': 'MergeTree', 'sorting_key': 'tuple()'}
+    errors_discarded_at: str | None
+    headers: dict
+    id: str
+    last_commit: dict  # TODO: {'content_sha': '', 'path': '', 'status': 'ok'}
+    name: str
+    project: str | None
+    replicated: bool
+    shared_with: list  # TODO
+    tags: dict
+    type: str
+    updated_at: str
+    used_by: list  # TODO
+    version: int
+
+
+class ListDataSourcesResponse(ApiResponse):
+    @property
+    def datasources(self) -> list[DataSourceInfo]:
+        return self.json().get("datasources", [])
+
+
+class AppendDataResponse(ApiResponse):
+    @property
+    def datasource(self) -> DataSourceAppendInfo:
+        return self.json().get("datasource", {})
+
+    @property
+    def import_id(self) -> str:
+        return self.json().get("import_id")
+
+    @property
+    def invalid_lines(self) -> int:
+        return self.json().get("invalid_lines")
+
+    @property
+    def quarantine_rows(self) -> int:
+        return self.json().get("quarantine_rows")
+
+    @property
+    def error(self) -> str | None:
+        error = self.json().get("error")
+        if not error:
+            return None
+        return error
+
+
+class GetDataSourceInformationResponse(ApiResponse):
+    @property
+    def info(self) -> DataSourceInfo:
+        """
+        Returns the data source information.
+
+        Example::
+
+        {
+            "id": "t_bd1c62b5e67142bd9bf9a7f113a2b6ea",
+            "name": "datasource_name",
+            "statistics": {
+                "bytes": 430833,
+                "row_count": 3980
+            },
+            "used_by": [{
+                "id": "t_efdc62b5e67142bd9bf9a7f113a34353",
+                "name": "pipe_using_datasource_name"
+            }]
+            "updated_at": "2018-09-07 23:50:32.322461",
+            "created_at": "2018-11-28 23:50:32.322461",
+            "type": "csv"
+        }
+
+        """
+        return self.json()
+
+
+class DataSourcesApi(Api):
+    """
+    ``/v0/datasources`` API client.
+
+    TODO: missing APIs:
+     * Creating data sources (POST /v0/datasources with mode=create)
+     * Replacing data sources (POST /v0/datasources with mode=replace)
+     * Alter data source (POST /v0/datasources/:name/alter)
+     * Delete data (POST /v0/datasources/:name/delete)
+     * Drop data source (DELETE /v0/datasources/:name)
+     * Update data source attributes (PUT /v0/datasources/:name)
+    """
+
+    endpoint: str = "/v0/datasources"
+
+    session: requests.Session
+
+    def __init__(self, token: str, host: str = None):
+        super().__init__(token, host)
+
+        self.session = requests.Session()
+        if self.token:
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+
+    def append(
+        self,
+        name: str,
+        data: str | bytes | Iterable[bytes] | Iterable[str],
+        dialect_delimiter: str = None,
+        dialect_new_line: str = None,
+        dialect_escapechar: str = None,
+        progress: bool = False,
+        format: Literal["csv", "ndjson", "parquet"] = None,
+    ) -> AppendDataResponse:
+        """
+        Makes a POST request to ``/v0/datasources`` endpoint with mode=append, which appends data to the datasource.
+
+        The data is expected to already be encoded in the format specified by the format parameter. You can pass
+        generators or other iterables as data. For example::
+
+            records = [...]  # some list of dicts
+
+            def _data():
+                # creates an NDJSON stream
+                for r in records:
+                    yield json.dumps(r) + "\\n"
+
+            response = ds.append("my_table", _data(), format="ndjson")
+
+        :param name: Name of the data source to append data to.
+        :param data: Data to append.
+        :param dialect_delimiter: The one-character string separating the fields. We try to guess the delimiter based
+            on the CSV contents using some statistics, but sometimes we fail to identify the correct one. If you know
+            your CSV’s field delimiter, you can use this parameter to explicitly define it.
+        :param dialect_new_line: The one- or two-character string separating the records. We try to guess the delimiter
+            based on the CSV contents using some statistics, but sometimes we fail to identify the correct one. If you
+            know your CSV’s record delimiter, you can use this parameter to explicitly define it.
+        :param dialect_escapechar: The escapechar removes any special meaning from the following character. This is
+            useful if the CSV does not use double quotes to encapsulate a column but uses double quotes in the content
+            of a column and it is escaped with, e.g. a backslash.
+        :param progress: When using true and sending the data in the request body, Tinybird will return block status
+            while loading using Line-delimited JSON. TODO: currently not supported
+        :param format: Default: csv. Indicates the format of the data to be ingested in the Data Source. By default is
+            csv and you should specify format=ndjson for NDJSON format, and format=parquet for Parquet files.
+        :return: A ``AppendDataResponse`` object.
+        """
+        if progress:
+            raise NotImplementedError
+
+        params = {
+            "mode": "append",
+            "name": name,
+        }
+
+        if dialect_delimiter:
+            params["dialect_delimiter"] = dialect_delimiter
+        if dialect_new_line:
+            params["dialect_new_line"] = dialect_new_line
+        if dialect_escapechar:
+            params["dialect_escapechar"] = dialect_escapechar
+        if format:
+            params["format"] = format
+
+        headers = {}
+        if format == "csv":
+            headers["Content-Type"] = "text/html; charset=utf-8"
+        if format == "ndjson":
+            headers["Content-Type"] = "application/x-ndjson; charset=utf-8"
+
+        response = self.session.request(
+            method="POST",
+            url=f"{self.host}{self.endpoint}",
+            params=params,
+            headers=headers,
+            data=data,
+        )
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return AppendDataResponse(response)
+
+    def list(self) -> ListDataSourcesResponse:
+        """
+        Makes a GET request to ``/v0/datasources`` endpoint, which returns a list of datasources.
+
+        :return: A ``ListDataSourcesResponse`` object
+        """
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}{self.endpoint}",
+        )
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return ListDataSourcesResponse(response)
+
+    def get_information(self, name: str) -> GetDataSourceInformationResponse:
+        """
+        Makes a GET request to ``/v0/datasources/<name>`` endpoint, which returns information about the datasource.
+
+        :param name: The name of the datasource to get information about.
+        :return: A ``GetDataSourceInformationResponse``
+        """
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}{self.endpoint}/{name}",
+        )
+
+        if response.status_code == 404:
+            raise DataSourceNotFoundError(response)
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return GetDataSourceInformationResponse(response)
+
+    def truncate(self, name: str):
+        """
+        Makes a POST request to ``/v0/datasources/:name/truncate``, which truncates the datasource.
+
+        :param name: The name of the datasource to truncate.
+        """
+        response = self.session.request(
+            method="POST",
+            url=f"{self.host}{self.endpoint}/{name}/truncate",
+        )
+
+        if response.status_code == 404:
+            raise DataSourceNotFoundError(response)
+
+        if not response.ok:
+            raise ApiError(response)

--- a/verdin/api/events.py
+++ b/verdin/api/events.py
@@ -1,0 +1,83 @@
+import gzip
+import json
+import logging
+
+import requests
+
+from .base import Api, ApiError, ApiResponse
+
+LOG = logging.getLogger(__name__)
+
+
+class EventsResponse(ApiResponse):
+    @property
+    def successful_rows(self) -> int:
+        return self.json().get("successful_rows")
+
+    @property
+    def quarantined_rows(self) -> int:
+        return self.json().get("quarantined_rows")
+
+
+class EventsApi(Api):
+    endpoint: str = "/v0/events"
+
+    session: requests.Session
+
+    def __init__(self, token: str, host: str = None):
+        super().__init__(token, host)
+
+        self.session = requests.Session()
+        if self.token:
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+
+    def send(
+        self,
+        name: str,
+        records: list[dict],
+        wait: bool = False,
+        json_encoder: type = None,
+        compress: bool = False,
+    ) -> EventsResponse:
+        """
+        Makes a POST request to ``/v0/events?name=<name>`` with NDJSON encoded data.
+
+        :param name: Name or ID of the target Data Source to append data to it
+        :param records: List of JSON records to append. Records will be converted to NDJSON using ``json.dumps``
+        :param wait: 'false' by default. Set to 'true' to wait until the write is acknowledged by the database.
+            Enabling this flag makes it possible to retry on database errors, but it introduces additional latency.
+            It's recommended to enable it in use cases in which data loss avoidance is critical. Disable it otherwise.
+        :param json_encoder: The JSON Encoder class passed to ``json.dumps``. Defaults to ``json.JSONEncoder``.
+        :param compress: Whether to compress the data using gzip. Defaults to False.
+
+        :return: The EventsResponse
+        :raises ApiError: If the request failed
+        """
+        url = f"{self.host}{self.endpoint}"
+
+        docs = [json.dumps(doc, cls=json_encoder) for doc in records]
+        data = "\n".join(docs)
+
+        params = {"name": name}
+        if wait:
+            params["wait"] = "true"
+
+        LOG.debug("sending %d ndjson records to %s via %s", len(records), name, url)
+
+        headers = {"Content-Type": "application/x-ndjson"}
+
+        if compress:
+            headers["Content-Encoding"] = "gzip"
+            data = gzip.compress(data.encode("utf-8"))
+
+        response = self.session.post(
+            url=url,
+            params=params,
+            headers=headers,
+            data=data,
+        )
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return EventsResponse(response)

--- a/verdin/api/events.py
+++ b/verdin/api/events.py
@@ -12,11 +12,11 @@ LOG = logging.getLogger(__name__)
 class EventsResponse(ApiResponse):
     @property
     def successful_rows(self) -> int:
-        return self.json().get("successful_rows")
+        return self.json.get("successful_rows")
 
     @property
     def quarantined_rows(self) -> int:
-        return self.json().get("quarantined_rows")
+        return self.json.get("quarantined_rows")
 
 
 class EventsApi(Api):

--- a/verdin/api/pipes.py
+++ b/verdin/api/pipes.py
@@ -1,0 +1,311 @@
+import csv
+import json
+from typing import TypedDict, Literal
+
+import requests
+
+from .base import Api, ApiResponse, ApiError
+
+PipeOutputFormat = Literal["csv", "json", "ndjson", "parquet", "prometheus"]
+
+
+class PipeNotFoundError(ApiError):
+    """
+    Specific ApiError representing a 404 Not Found when pipe names are given.
+    """
+
+
+class PipeNode(TypedDict):
+    id: str
+    name: str
+    sql: str
+    deployment_suffix: str | None
+    description: str | None
+    materialized: bool | None
+    cluster: str | None
+    tags: dict
+    created_at: str
+    updated_at: str
+    version: int
+    project: str | None
+    result: str | None
+    ignore_sql_errors: bool
+    node_type: str
+    dependencies: list[str] | None
+    params: list | None
+
+
+class PipeListInfo(TypedDict):
+    id: str
+    name: str
+    description: str
+    endpoint: str
+    created_at: str
+    updated_at: str
+    parent: str | None
+    nodes: list[PipeNode]
+    url: str
+
+
+class PipeInfo(TypedDict):
+    """
+    A document returned by the pipe information endpoint. Example::
+
+    {
+      "content": "VERSION 0\n\nDESCRIPTION >\n    Endpoint to select unique ...",
+      "created_at": "2025-12-17 13:18:09.799374",
+      "description": "Endpoint to select unique key/value pairs from simple",
+      "edited_by": null,
+      "endpoint": "t_54dffae578ef47238fd51e9849f79a1f",
+      "id": "t_c50152ced57b46b99acf14930b9c6906",
+      "last_commit": {
+        "content_sha": "",
+        "path": "",
+        "status": "None"
+      },
+      "name": "simple_kv",
+      "nodes": [
+        {
+          "cluster": null,
+          "created_at": "2025-12-17 13:18:09.799385",
+          "dependencies": [
+            "simple"
+          ],
+          "deployment_suffix": "",
+          "description": null,
+          "id": "t_54dffae578ef47238fd51e9849f79a1f",
+          "ignore_sql_errors": false,
+          "materialized": null,
+          "name": "endpoint",
+          "node_type": "endpoint",
+          "params": [],
+          "project": null,
+          "result": null,
+          "sql": "%\n    SELECT key, value\n    FROM simple\n    ...",
+          "tags": {},
+          "updated_at": "2025-12-17 13:18:09.799385",
+          "version": 0
+        }
+      ],
+      "parent": null,
+      "path": "endpoints/simple_kv.pipe",
+      "type": "endpoint",
+      "updated_at": "2025-12-17 13:18:09.799394",
+      "url": "http://localhost:8001/v0/pipes/simple_kv.json",
+      "workspace_id": "2244743a-d384-478f-a9f5-ea4848c56427"
+    }
+    """
+
+    content: str
+    created_at: str
+    description: str
+    edited_by: str | None
+    endpoint: str
+    id: str
+    last_commit: dict
+    name: str
+    nodes: list[PipeNode]
+    parent: str | None
+    path: str
+    type: str
+    updated_at: str
+    url: str
+    workspace_id: str
+
+
+class ListPipesResponse(ApiResponse):
+    @property
+    def pipes(self) -> list[PipeListInfo]:
+        return self.json.get("pipes", [])
+
+
+class GetPipeInformationResponse(ApiResponse):
+    @property
+    def info(self) -> PipeInfo:
+        return self.json
+
+
+class QueryPipeResponse(ApiResponse):
+    @property
+    def data(self) -> list[dict]:
+        raise NotImplementedError
+
+
+class QueryPipeJsonResponse(QueryPipeResponse):
+    @property
+    def data(self) -> list[dict]:
+        return self.json.get("data", [])
+
+    @property
+    def meta(self) -> list[dict]:
+        return self.json.get("meta", [])
+
+    @property
+    def rows(self) -> int:
+        return self.json.get("rows")
+
+    @property
+    def statistics(self) -> dict:
+        return self.json.get("statistics", {})
+
+
+class QueryPipeNdjsonResponse(QueryPipeResponse):
+    @property
+    def data(self) -> list[dict]:
+        """Parses the CSV response body into a list of dictionaries."""
+        for line in self.text.splitlines():
+            print(line)
+            json.loads(line)
+        return [json.loads(line) for line in self.text.strip().splitlines()]
+
+
+class QueryPipeCsvResponse(QueryPipeResponse):
+    @property
+    def data(self) -> list[dict]:
+        """Parses the CSV response body into a list of dictionaries."""
+        reader = csv.DictReader(self.text.splitlines())
+        return list(reader)
+
+
+class PipesApi(Api):
+    """
+    Pipes API. See https://www.tinybird.co/docs/api-reference/pipe-api
+
+    TODO: missing APIs to implement
+        * Creating a new pipe (POST /v0/pipes)
+        * Append a node to a pipe (POST /v0/pipes/:name/nodes)
+        * Delete a node from a pipe (DELETE /v0/pipes/:name/nodes/:node_id)
+        * Update a node in a pipe (PUT /v0/pipes/:name/nodes/:node_id)
+        * Delete a pipe (DELETE /v0/pipes/:name)
+        * Change a pipe's metadata (PUT /v0/pipes/:name)
+        * Explain a pipe (GET /v0/pipes/:name/explain)
+    """
+
+    endpoint: str = "/v0/pipes"
+
+    session: requests.Session
+
+    def __init__(self, token: str, host: str = None):
+        super().__init__(token, host)
+
+        self.session = requests.Session()
+        if self.token:
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+
+    def list(
+        self,
+        dependencies: bool = False,
+        attrs: list[str] = None,
+        node_attrs: list[str] = None,
+    ) -> ListPipesResponse:
+        """
+        Get a list of pipes in your account. Makes a GET request to ``/v0/pipes`` endpoint, which returns a list of
+        pipes.
+
+        :param dependencies: Include dependent data sources and pipes, default is false
+        :param attrs: List of pipe attributes to return (e.g. '["name","description"]')
+        :param node_attrs: List of node attributes to return (e.g. '["id","name"]')
+        :return: A ``ListPipesResponse`` object
+        """
+        params = {}
+        if dependencies:
+            params["dependencies"] = "true"
+        if attrs:
+            params["attrs"] = ",".join(attrs)
+        if node_attrs:
+            params["node_attrs"] = ",".join(node_attrs)
+
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}{self.endpoint}",
+            params=params,
+        )
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return ListPipesResponse(response)
+
+    def query(
+        self,
+        name: str,
+        query: str = None,
+        parameters: dict[str, str] = None,
+        format: PipeOutputFormat = "json",
+    ) -> QueryPipeResponse | QueryPipeJsonResponse | QueryPipeNdjsonResponse | QueryPipeCsvResponse:
+        """
+        Query the Pipe. Makes a GET request to ``/v0/pipes/<name>.<format>`` endpoint, which returns the query result.
+        The return value depends on the format parameter. Currently, parquet and prometheus formats are only supported
+        as raw outputs. For all others you can call ``response.data`` and receive a list of dictionary records.
+
+        When using an additional SQL query (through the ``query`` parameter) for the Pipe, you can use the
+        ``_`` shortcut, which refers to your Pipe name. You can pass both ``parameters`` and ``query``.
+
+        :param name: The name of the pipe to query.
+        :param query: Optional query to execute against the pipe.
+        :param parameters: The dynamic parameters passed to the pipe.
+        :param format: The output format (default: json).
+        :return: A ``QueryPipeResponse`` object that is specific to the output format.
+        """
+
+        params = dict(parameters) if parameters else {}
+        if query:
+            params["q"] = query
+
+        # if the query is too large, the web server (nginx) will respond with "414 Request-URI Too Large". it seems
+        # this limit is around 8kb, so if it's too large, we use a POST request instead.
+        qsize = 1  # include the "?" character
+        for k, v in params.items():
+            qsize += len(k) + len(v) + 2  # include the ``&`` and ``=`` character
+
+        if qsize > 8192:
+            response = self.session.request(
+                method="POST",
+                url=f"{self.host}{self.endpoint}/{name}.{format}",
+                data=params,
+            )
+        else:
+            response = self.session.request(
+                method="GET",
+                url=f"{self.host}{self.endpoint}/{name}.{format}",
+                params=params,
+            )
+
+        if response.status_code == 404:
+            raise PipeNotFoundError(response)
+
+        if not response.ok:
+            raise ApiError(response)
+
+        # format-specific response objects
+        if format == "json":
+            return QueryPipeJsonResponse(response)
+        if format == "ndjson":
+            return QueryPipeNdjsonResponse(response)
+        if format == "csv":
+            return QueryPipeCsvResponse(response)
+
+        # prometheus and parquet formats are currently only supported as raw outputs
+
+        return QueryPipeResponse(response)
+
+    def get_information(self, name: str) -> GetPipeInformationResponse:
+        """
+        Makes a GET request to ``/v0/pipes/<name>`` endpoint, which returns the pipe information.
+        See: https://www.tinybird.co/docs/api-reference/pipe-api#get--v0-pipes-(.+\.pipe)
+
+        :param name: The name or ID of the pipe.
+        :return: A ``GetPipeInformationResponse`` object
+        """
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}{self.endpoint}/{name}",
+        )
+
+        if response.status_code == 404:
+            raise PipeNotFoundError(response)
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return GetPipeInformationResponse(response)

--- a/verdin/api/tokens.py
+++ b/verdin/api/tokens.py
@@ -1,0 +1,97 @@
+from typing import TypedDict
+
+import requests
+
+from verdin.api import ApiResponse
+from verdin.api.base import Api, ApiError
+
+
+class TokenNotFoundError(ApiError):
+    """Specific ApiError representing a 404 Not Found when token names are given."""
+
+
+class Scope(TypedDict):
+    type: str
+    resource: str | None
+    filter: str | None
+
+
+class TokenInfo(TypedDict):
+    id: str
+    token: str
+    scopes: list[Scope]
+    name: str
+    description: str | None
+    origin: dict | None
+    host: str
+    is_internal: bool
+
+
+class ListTokensResponse(ApiResponse):
+    @property
+    def tokens(self) -> list[TokenInfo]:
+        return self.json.get("tokens", [])
+
+
+class GetTokenInfoResponse(ApiResponse):
+    @property
+    def info(self) -> TokenInfo:
+        return self.json
+
+
+class TokensApi(Api):
+    """
+    Tokens API client.
+
+    TODO: The following APIs are not yet implemented (note that some workspaces only allow resource modification
+     through deployments anyway)
+     - Create a new Token: Static or JWT (POST /v0/tokens)
+     - Refresh a static token (POST /v0/tokens/:name/refresh)
+     - Delete a Token (DELETE /v0/tokens/:name)
+     - Modify a Token (PUT /v0/tokens/:name)
+    """
+
+    endpoint: str = "/v0/tokens"
+
+    session: requests.Session
+
+    def __init__(self, token: str, host: str = None):
+        super().__init__(token, host)
+
+        self.session = requests.Session()
+        if self.token:
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+
+    def get_information(self, token: str):
+        """
+        Fetches information about a particular Static Token. Makes a GET request to ``/v0/tokens/:name``. If the token
+        doesn't exist, a 403 may be returned ("Not enough permissions to get information about this token").
+
+        :param token: The token identifier.
+        :return: A ``GetTokenInfoResponse`` object.
+        """
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}{self.endpoint}/{token}",
+        )
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return GetTokenInfoResponse(response)
+
+    def list(self) -> ListTokensResponse:
+        """
+        Retrieves all workspace Static Tokens. Makes a GET request to ``/v0/tokens``.
+
+        :return: A ``ListTokensResponse`` object.
+        """
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}{self.endpoint}",
+        )
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return ListTokensResponse(response)

--- a/verdin/api/variables.py
+++ b/verdin/api/variables.py
@@ -1,0 +1,213 @@
+from typing import TypedDict, Literal
+
+import requests
+
+from verdin.api.base import Api, ApiError, ApiResponse
+
+
+class VariableNotFoundError(ApiError):
+    """
+    Specific ApiError representing a 404 Not Found when variable names are given.
+    """
+
+
+class VariableInfo(TypedDict):
+    """
+    A variable info object. Example::
+
+        {
+            "name": "test_password",
+            "type": "secret",
+            "created_at": "2024-06-21T10:27:57",
+            "updated_at": "2024-06-21T10:27:57",
+            "edited_by": "token: 'admin token'"
+        }
+    """
+
+    name: str
+    type: str
+    created_at: str
+    updated_at: str
+    edited_by: str
+
+
+class CreateVariableResponse(ApiResponse):
+    @property
+    def variable(self) -> VariableInfo:
+        """
+        Returns the variable information.
+        """
+        return self.json
+
+
+class UpdateVariableResponse(ApiResponse):
+    @property
+    def variable(self) -> VariableInfo:
+        """
+        Returns the variable information.
+        """
+        return self.json
+
+
+class DeleteVariableResponse(ApiResponse):
+    @property
+    def ok(self) -> bool:
+        """
+        Returns whether the operation was successful.
+        """
+        return self.json.get("ok", False)
+
+
+class ListVariablesResponse(ApiResponse):
+    @property
+    def variables(self) -> list[VariableInfo]:
+        """
+        Returns the list of variables.
+        """
+        return self.json.get("variables", [])
+
+
+class GetVariableResponse(ApiResponse):
+    @property
+    def variable(self) -> VariableInfo:
+        """
+        Returns the variable information.
+        """
+        return self.json
+
+
+class VariablesApi(Api):
+    """
+    ``/v0/variables`` API client.
+
+    This API allows you to create, update, delete, and list environment variables
+    that can be used in Pipes in a Workspace.
+    """
+
+    endpoint: str = "/v0/variables"
+
+    session: requests.Session
+
+    def __init__(self, token: str, host: str = None):
+        super().__init__(token, host)
+
+        self.session = requests.Session()
+        if self.token:
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+
+    def create(
+        self,
+        name: str,
+        value: str,
+        type: Literal["secret"] = "secret",
+    ) -> CreateVariableResponse:
+        """
+        Creates a new environment variable.
+
+        :param name: The name of the variable.
+        :param value: The value of the variable.
+        :param type: The type of the variable. Defaults to 'secret'.
+        :return: A ``CreateVariableResponse`` object.
+        """
+        data = {
+            "name": name,
+            "value": value,
+            "type": type,
+        }
+
+        response = self.session.request(
+            method="POST",
+            url=f"{self.host}{self.endpoint}",
+            data=data,
+        )
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return CreateVariableResponse(response)
+
+    def delete(self, name: str) -> DeleteVariableResponse:
+        """
+        Deletes an environment variable.
+
+        :param name: The name of the variable to delete.
+        :return: A ``DeleteVariableResponse`` object.
+        """
+        response = self.session.request(
+            method="DELETE",
+            url=f"{self.host}{self.endpoint}/{name}",
+        )
+
+        if response.status_code == 404:
+            raise VariableNotFoundError(response)
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return DeleteVariableResponse(response)
+
+    def update(
+        self,
+        name: str,
+        value: str,
+    ) -> UpdateVariableResponse:
+        """
+        Updates an environment variable.
+
+        :param name: The name of the variable to update.
+        :param value: The new value of the variable.
+        :return: A ``UpdateVariableResponse`` object.
+        """
+        data = {
+            "value": value,
+        }
+
+        response = self.session.request(
+            method="PUT",
+            url=f"{self.host}{self.endpoint}/{name}",
+            data=data,
+        )
+
+        if response.status_code == 404:
+            raise VariableNotFoundError(response)
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return UpdateVariableResponse(response)
+
+    def list(self) -> ListVariablesResponse:
+        """
+        Lists all environment variables.
+
+        :return: A ``ListVariablesResponse`` object.
+        """
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}{self.endpoint}",
+        )
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return ListVariablesResponse(response)
+
+    def get(self, name: str) -> GetVariableResponse:
+        """
+        Gets information about a specific environment variable.
+
+        :param name: The name of the variable to get.
+        :return: A ``GetVariableResponse`` object.
+        """
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}{self.endpoint}/{name}",
+        )
+
+        if response.status_code == 404:
+            raise VariableNotFoundError(response)
+
+        if not response.ok:
+            raise ApiError(response)
+
+        return GetVariableResponse(response)

--- a/verdin/client.py
+++ b/verdin/client.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from . import config
+from .api.apis import Apis
 from .datasource import Datasource
 from .pipe import Pipe
 from .query import OutputFormat, SqlQuery
@@ -12,21 +13,30 @@ class Client:
     """
 
     def __init__(self, token: str, api: str = None):
-        self.api = (api or config.API_URL).lstrip("/")
+        self.host = (api or config.API_URL).lstrip("/")
         self.token = token
+        self._api = Apis(self.token, self.host)
+
+    @property
+    def api(self) -> Apis:
+        """
+        Returns an ``Apis`` object that gives you access to the tinybird API objects.
+        :return: An ``Apis`` object
+        """
+        return self._api
 
     def pipe(self, name: str, version: int = None) -> Pipe:
         """
         Create an object representing a pipe with the given name, e.g.,
         "localstack_dashboard_events.json"
         """
-        return Pipe(name, token=self.token, version=version, api=self.api)
+        return Pipe(name, token=self.token, version=version, api=self.host)
 
     def datasource(self, name: str, version: int = None) -> Datasource:
         """
         Create an object representing a datasource with a given name.
         """
-        return Datasource(name, token=self.token, version=version, api=self.api)
+        return Datasource(name, token=self.token, version=version, api=self.host)
 
     def sql(self, sql: str, format: Optional[OutputFormat] = None) -> SqlQuery:
-        return SqlQuery(sql, format=format, token=self.token, api=self.api)
+        return SqlQuery(sql, format=format, token=self.token, api=self.host)

--- a/verdin/datasource.py
+++ b/verdin/datasource.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 import requests
 
 from . import config
+from .api.datasources import DataSourcesApi
+from .api.events import EventsApi, EventsResponse
 
 if TYPE_CHECKING:
     from _typeshed import SupportsWrite
@@ -66,7 +68,12 @@ class Datasource:
         self.name = name
         self.token = token
         self.version = version
-        self.api = (api or config.API_URL).rstrip("/") + self.endpoint
+        self._host = (api or config.API_URL).rstrip("/")
+        self.api = self._host + self.endpoint
+
+        # API clients used to make the actual API calls
+        self._events_api = EventsApi(token, self._host)
+        self._datasources_api = DataSourcesApi(token, self._host)
 
     @property
     def canonical_name(self) -> str:
@@ -82,6 +89,24 @@ class Datasource:
         else:
             return self.name
 
+    def send_events(
+        self, records: list[dict], wait: bool = False, json_encoder: type = None
+    ) -> EventsResponse:
+        """
+        Uses the ``/v0/events`` API endpoint to send JSON data to the datasource.
+
+        :param records: List of JSON records to append. Records will be converted to NDJSON using ``json.dumps``
+        :param wait: 'false' by default. Set to 'true' to wait until the write is acknowledged by the database.
+            Enabling this flag makes it possible to retry on database errors, but it introduces additional latency.
+            It's recommended to enable it in use cases in which data loss avoidance is critical. Disable it otherwise.
+        :param json_encoder: The JSON Encoder class passed to ``json.dumps``. Defaults to ``json.JSONEncoder``.
+        :return: The EventsResponse from the ``EventsApi``.
+        :raises ApiError: If the request failed
+        """
+        return self._events_api.send(
+            self.canonical_name, records=records, wait=wait, json_encoder=json_encoder
+        )
+
     def append(self, records: Records, *args, **kwargs) -> requests.Response:
         """Calls ``append_csv``."""
         # TODO: replicate tinybird API concepts instead of returning Response
@@ -95,25 +120,24 @@ class Datasource:
         :param delimiter: Optional delimiter (defaults to ",")
         :return: The HTTP response
         """
-        params = {"name": self.canonical_name, "mode": "append"}
-        if delimiter:
-            params["dialect_delimiter"] = delimiter
-
-        headers = {"Content-Type": "text/html; charset=utf-8"}
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
 
         data = self.to_csv(records, delimiter=delimiter)
 
         LOG.debug(
-            "appending %d csv records to %s via %s(%s)",
+            "appending %d csv records to %s via %s",
             len(records),
             self,
             self.api,
-            params,
         )
-        # TODO: use multipart
-        return requests.post(url=self.api, params=params, headers=headers, data=data)
+
+        response = self._datasources_api.append(
+            name=self.canonical_name,
+            dialect_delimiter=delimiter,
+            format="csv",
+            data=data,
+        )
+
+        return response._response
 
     def append_ndjson(self, records: List[Dict]) -> requests.Response:
         """
@@ -122,39 +146,30 @@ class Datasource:
         :param records: List of JSON records to append. The will be converted to NDJSON using ``json.dumps``
         :return: The HTTP response
         """
-        # TODO: generalize appending in different formats
-        query = {"name": self.canonical_name, "mode": "append", "format": "ndjson"}
 
-        headers = {"Content-Type": "application/x-ndjson; charset=utf-8"}
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-
-        docs = [json.dumps(record) for record in records]
-        data = "\n".join(docs)
+        def _ndjson_iterator():
+            for record in records:
+                yield json.dumps(record) + "\n"
 
         LOG.debug(
-            "appending %d ndjson records to %s via %s(%s)",
+            "appending %d ndjson records to %s via %s",
             len(records),
             self,
             self.api,
-            query,
         )
-        return requests.post(url=self.api, params=query, headers=headers, data=data)
+        response = self._datasources_api.append(
+            name=self.canonical_name,
+            format="ndjson",
+            data=_ndjson_iterator(),
+        )
+
+        return response._response
 
     def truncate(self):
         """
         Truncate the datasource which removes all records in the table.
         """
-        headers = {}
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-
-        url = f"{self.api}/{self.canonical_name}/truncate"
-        LOG.debug(
-            "truncating table %s",
-            self.canonical_name,
-        )
-        requests.post(url=url, headers=headers)
+        self._datasources_api.truncate(name=self.canonical_name)
 
     @staticmethod
     def to_csv(records: List[List[Any]], **kwargs):

--- a/verdin/datasource.py
+++ b/verdin/datasource.py
@@ -116,7 +116,7 @@ class Datasource:
         """
         Makes a POST request to the datasource using mode=append with CSV data. This appends data to the table.
 
-        :param records: List of records to append. The will be converted to CSV using the provided delimiter.
+        :param records: List of records to append. They will be converted to CSV using the provided delimiter.
         :param delimiter: Optional delimiter (defaults to ",")
         :return: The HTTP response
         """
@@ -143,7 +143,7 @@ class Datasource:
         """
         Makes a POST request to the datasource using mode=append with ndjson data. This appends data to the table.
 
-        :param records: List of JSON records to append. The will be converted to NDJSON using ``json.dumps``
+        :param records: List of JSON records to append. They will be converted to NDJSON using ``json.dumps``
         :return: The HTTP response
         """
 


### PR DESCRIPTION
# Motivation

I've wanted better API clients for a while, where classes map to the actual APIs and their API concepts. These can then be used to implement higher-level abstractions like the `DataSource` class.

With #4 , it's now massively easier to develop and test this, so I went on a quest to implement the most important APIs.

The following APIs have been (partially) implemented, and can be accessed through `Client.api`:

* `/v0/datasources`: `client.api.datasources`
* `/v0/events`: `client.api.events`
* `/v0/pipes`: `client.api.pipes`
* `/v0/tokens`: `client.api.tokens`
* `/v0/variables`: `client.api.variables`


## Examples

For example, you can query a pipe using the pipes API:

```python
from verdin import tinybird

client = tinybird.Client(...)

response = client.api.pipes.query(
    "my_pipe",
    parameters={"my_param": "..."},
    query="SELECT * FROM _ LIMIT 10",
)

for record in response.data:
    # each record is a dictionary
    ...
```

Or use the HFI endpoint to append data:
```python
from verdin import tinybird

client = tinybird.Client(...)

response = client.api.events.send("my_datasource", records=[
    {"id": "...", "value": "..."},
    ...
])
assert response.quarantined_rows == 0
```

# Changes

* Introduce `verdin.api` which contains classes that map to APIs defined in https://www.tinybird.co/docs/api-reference/