### PR TITLE
fix issue where passing None as parameter to a query would fail

### DIFF
--- a/tests/integration/test_pipes.py
+++ b/tests/integration/test_pipes.py
@@ -126,6 +126,15 @@ class TestPipesApi:
         response = client.api.pipes.query("simple_pipe", parameters={"key": "does not exist"})
         assert response.data == []
 
+        # test with none parameters
+        response = client.api.pipes.query("simple_pipe", parameters={"key": None})
+        # simple check to make sure it returned all items
+        assert [(record["key"], record["value"]) for record in response.data] == [
+            ("foo", "bar"),
+            ("baz", "ed"),
+            ("foo", "bar2"),
+        ]
+
     def test_query_with_sql(self, client):
         client.api.events.send(
             "simple",

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -58,6 +58,19 @@ class TestQueryApi:
         assert response.rows == 1
         assert response.statistics["rows_read"] == 2
 
+    def test_query_pipe_with_none_parameters(self, client):
+        response = client.api.query.query(
+            "SELECT key, value FROM simple_pipe ORDER BY key ASC", parameters={"key": None}
+        )
+
+        assert response.data == [{"key": "baz", "value": "ed"}, {"key": "foo", "value": "bar"}]
+        assert response.meta == [
+            {"name": "key", "type": "String"},
+            {"name": "value", "type": "String"},
+        ]
+        assert response.rows == 2
+        assert response.statistics["rows_read"] == 2
+
     def test_query_pipeline_json(self, client):
         response = client.api.query.query(
             "SELECT * FROM _ ORDER BY `key` ASC", pipeline="simple_kv"

--- a/verdin/__init__.py
+++ b/verdin/__init__.py
@@ -1,3 +1,3 @@
 name = "verdin"
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/verdin/api/pipes.py
+++ b/verdin/api/pipes.py
@@ -230,7 +230,7 @@ class PipesApi(Api):
         self,
         name: str,
         query: str = None,
-        parameters: dict[str, str] = None,
+        parameters: dict[str, str | None] = None,
         format: PipeOutputFormat = "json",
     ) -> QueryPipeResponse | QueryPipeJsonResponse | QueryPipeNdjsonResponse | QueryPipeCsvResponse:
         """
@@ -256,6 +256,8 @@ class PipesApi(Api):
         # this limit is around 8kb, so if it's too large, we use a POST request instead.
         qsize = 1  # include the "?" character
         for k, v in params.items():
+            if v is None:
+                continue
             qsize += len(k) + len(v) + 2  # include the ``&`` and ``=`` character
 
         if qsize > 8192:

--- a/verdin/api/query.py
+++ b/verdin/api/query.py
@@ -161,7 +161,7 @@ class QueryApi(Api):
         self,
         query: str,
         pipeline: str = None,
-        parameters: dict[str, str] = None,
+        parameters: dict[str, str | None] = None,
         output_format_json_quote_64bit_integers: bool = False,
         output_format_json_quote_denormals: bool = False,
         output_format_parquet_string_as_string: bool = False,
@@ -216,6 +216,8 @@ class QueryApi(Api):
         # this limit is around 8kb, so if it's too large, we use a POST request instead.
         qsize = 1  # include the "?" character
         for k, v in data.items():
+            if v is None:
+                continue
             qsize += len(k) + len(v) + 2  # include the ``&`` and ``=`` character
 
         if qsize > 8192 or parameters:

--- a/verdin/test/container.py
+++ b/verdin/test/container.py
@@ -8,6 +8,8 @@ from verdin.client import Client
 
 
 class TinybirdLocalContainer:
+    # TODO: easier configuration of compatibility mode
+
     def __init__(self, cwd: str = None):
         """
         Creates a new TinybirdLocalContainer instance.


### PR DESCRIPTION
# Motivation

It was pointed out by the platform team, specifically @Pive01 (thank you! :pray:), that #6 introduced a bug, where you could no longer pass `None` as a parameter value. This created a failure downstream. For example, this is a reasonable way to create a param dict:

```python
parameters = {
   "since": since.isoformat() if since else None
}
```

This PR adds tests, updates the type hints, and fixes the underlying error. Also bumps the version to 0.5.2

# Changes

* `None` values can now be passed as parameters again to the `query` and `pipes` api.