### PR TITLE
fix SyntaxWarning in pipes.py docstring for Python 3.12 [DAT-817]

### DIFF
--- a/verdin/api/pipes.py
+++ b/verdin/api/pipes.py
@@ -292,7 +292,7 @@ class PipesApi(Api):
         return QueryPipeResponse(response)
 
     def get_information(self, name: str) -> GetPipeInformationResponse:
-        """
+        r"""
         Makes a GET request to ``/v0/pipes/<name>`` endpoint, which returns the pipe information.
         See: https://www.tinybird.co/docs/api-reference/pipe-api#get--v0-pipes-(.+\.pipe)
 


### PR DESCRIPTION
## Summary

Converts the `get_information` docstring in `verdin/api/pipes.py` to a raw string (`r"""..."""`) to suppress a `SyntaxWarning: invalid escape sequence '\.'` raised by Python 3.12+. 

Surfaced during [DAT-815](https://linear.app/localstack/issue/DAT-815) integration test [run](https://github.com/localstack/analytics-backend/actions/runs/22571425950/job/65379991167).

## Risks & Validation

No behavioural change.

Warning observed in DAT-815 CI run:

```
=============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/verdin/api/pipes.py:295
  /home/runner/work/analytics-backend/analytics-backend/.venv/lib/python3.12/site-packages/verdin/api/pipes.py:295: SyntaxWarning: invalid escape sequence '\.'
    See: https://www.tinybird.co/docs/api-reference/pipe-api#get--v0-pipes-(.+\.pipe)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== PASSES ====================================
=================== 9 passed, 1 warning in 110.61s (0:01:50) ===================
```