### PR TITLE
fix: Send entire JSON, to send the Content-Length header [DAT-818]

### DIFF
--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -44,6 +44,28 @@ class TestDatasource:
         assert response.ok
 
 
+    def test_append_ndjson(self, httpserver: HTTPServer):
+        ds = Datasource("mydatasource", "123456", api=httpserver.url_for("/"))
+
+        records = [{"key": "foo", "value": "bar"}, {"key": "baz", "value": "ed"}]
+        expected_body = '{"key": "foo", "value": "bar"}\n{"key": "baz", "value": "ed"}\n'
+
+        httpserver.expect_request(
+            "/v0/datasources",
+            query_string={
+                "name": "mydatasource",
+                "mode": "append",
+                "format": "ndjson",
+            },
+            data=expected_body,
+            headers={"Content-Length": str(len(expected_body.encode()))},
+        ).respond_with_data("", 200)
+
+        response = ds.append_ndjson(records)
+        httpserver.check()
+        assert response.ok
+
+
 class TestFileDatasource:
     def test_append(self, tmp_path):
         file_path = tmp_path / "myfile.csv"

--- a/verdin/datasource.py
+++ b/verdin/datasource.py
@@ -147,9 +147,7 @@ class Datasource:
         :return: The HTTP response
         """
 
-        def _ndjson_iterator():
-            for record in records:
-                yield json.dumps(record) + "\n"
+        data = "".join(json.dumps(record) + "\n" for record in records)
 
         LOG.debug(
             "appending %d ndjson records to %s via %s",
@@ -160,7 +158,7 @@ class Datasource:
         response = self._datasources_api.append(
             name=self.canonical_name,
             format="ndjson",
-            data=_ndjson_iterator(),
+            data=data,
         )
 
         return response._response


### PR DESCRIPTION
# Summary
Sending data as generators does not set the Content-Length header in the POST request, which is required by the Tinybird /v0/datasources endpoint. Hence, calling the method `append_ndjson` throws the following error:
Already reported by @Pive01 in this Slack [thread](https://localstack-cloud.slack.com/archives/C07D6G0RP4K/p1772443968154449).

```
[ERROR] ApiError: API Error (411): Add a valid Content-Length header containing the length of the message-body. Documentation: https://docs.tinybird.co/api-reference/api-reference.html#limits
```

## Extra considerations:
* All data sources do not get more than 100 records per day
* The GitHub API caps the commit difference to 250 [[1](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits)]
* The `/v0/datasources` endpoint limit is at 5 times per minute [[2](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits)]

Since we receive few records to iterate over, it makes sense to keep sending data in batches via the `/v0/datasources` endpoint. Once more data flows, we can consider the usage of the `/v0/events` endpoint + generators.