### PR TITLE
add tag-based release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
+    branches: [ main ]
     paths-ignore:
-      - 'README.md'
-    branches:
-      - main
+      - "README.md"
+    tags:
+      - "v*.*"
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
 
 jobs:
   test:
@@ -20,10 +20,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -52,3 +54,36 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/verdin
+
+    permissions:
+      id-token: write
+
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build release
+        run: make dist
+
+      - name: List artifacts
+        run: ls -lah dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Hatch VCS hook generates this file during build
+verdin/version.py

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ test: venv
 test-coverage: venv
 	$(VENV_RUN); coverage run --source=verdin -m pytest tests && coverage lcov -o .coverage.lcov
 
-dist: venv
-	$(VENV_RUN); python -m build
+dist: clean-dist
+	python3 -m build
 
 install: venv
-	$(VENV_RUN); pip install -e .
+	$(VENV_RUN); pip install -e ".[dev]"
 
 upload: venv
 	$(VENV_RUN); pip install --upgrade twine; twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Verdin project configuration
 [build-system]
-requires = ['hatchling']
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -38,10 +38,14 @@ dev = [
     "pytest-cov>=2.7.1",
     "coveralls",
     "tinybird",
+    "build",
 ]
 
 [tool.hatch.version]
-path = "verdin/__init__.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "verdin/version.py"
 
 [tool.ruff]
 line-length = 100

--- a/verdin/__init__.py
+++ b/verdin/__init__.py
@@ -1,3 +1,3 @@
-name = "verdin"
+from verdin.version import __version__
 
-__version__ = "0.5.2"
+__all__ = ["__version__"]


### PR DESCRIPTION
## Motivation

This PR adds a tag-based release workflow based on our internal documentation on how to achieve this.

## Changes

* verdin now uses hatch-vcs to compute the version number